### PR TITLE
Add diacriticAndCaseInsensitive option to StringPredicate.contains()

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/StringContainsOperators.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/StringContainsOperators.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StringContainsOperators"
+               BuildableName = "StringContainsOperators"
+               BlueprintName = "StringContainsOperators"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StringContainsOperatorsTests"
+               BuildableName = "StringContainsOperatorsTests"
+               BlueprintName = "StringContainsOperatorsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StringContainsOperatorsTests"
+               BuildableName = "StringContainsOperatorsTests"
+               BlueprintName = "StringContainsOperatorsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "StringContainsOperators"
+            BuildableName = "StringContainsOperators"
+            BlueprintName = "StringContainsOperators"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ print(result2) // true
 // Check if text contains "fox" AND ("jumps" OR "swift")
 let result3 = text.contains("fox" && ("jumps" || "swift"))
 print(result3) // true
+
+// Check if text contains "Brown" OR "red" case insensitively and without diacritics
+let result4 = text.contains(~"Brown" || ~"red")
+print(result4) // true
+
+// Check if text contains "fox" AND ("Jumps" OR "swift") case insensitively and without diacritics
+let result5 = text.contains(~"fox" && (~"Jumps" || ~"swift"))
+print(result5) // true
 ```
 
 ## How to Install
@@ -43,7 +51,7 @@ You can install StringContainsOperators using Swift Package Manager (SPM). Simpl
 You can also install StringContainsOperators using CocoaPods. Simply add the following line to your Podfile:
 
 ```ruby
-pod 'StringContainsOperators', '~> 1.0'
+pod 'StringContainsOperators', '~> 1.1'
 ```
 
 ## Contributions

--- a/Tests/StringContainsOperatorsTests/StringContainsOperatorsTests.swift
+++ b/Tests/StringContainsOperatorsTests/StringContainsOperatorsTests.swift
@@ -8,84 +8,92 @@ final class StringContainsOperatorsTests: XCTestCase {
            XCTAssertTrue("Hello".contains(predicate))
            XCTAssertTrue("World".contains(predicate))
            XCTAssertFalse("Goodbye".contains(predicate))
-   }
-       
-   func testOrStringPredicate() {
+    }
+
+    func testOrStringPredicate() {
        let predicate = "Hello" || "World" || "Goodbye"
        XCTAssertTrue("Hello".contains(predicate))
        XCTAssertTrue("World".contains(predicate))
        XCTAssertTrue("Goodbye".contains(predicate))
        XCTAssertFalse("Goodnight".contains(predicate))
-   }
-   
-   func testOrPredicates() {
+    }
+
+    func testOrPredicates() {
        let predicate = "Hello" || ("W" && "o" && "r" && "l" && "d")
        XCTAssertTrue("Hello".contains(predicate))
        XCTAssertTrue("World".contains(predicate))
        XCTAssertFalse("Goodbye".contains(predicate))
        XCTAssertFalse("Hey".contains(predicate))
-   }
-   
-   func testAndStringPredicate() {
+    }
+
+    func testAndStringPredicate() {
        let predicate = "Hello" && "World"
        XCTAssertTrue("HelloWorld".contains(predicate))
        XCTAssertFalse("Hello".contains(predicate))
        XCTAssertFalse("World".contains(predicate))
        XCTAssertFalse("Goodbye".contains(predicate))
-   }
+    }
+
+    func testAndStringPredicateInsentitive() {
+        let predicate = ~"Hello" && ~"World" && "Apple"
+        XCTAssertTrue("HeLLoWórld Apple".contains(predicate))
+        XCTAssertTrue("HelloWORLDApple".contains(predicate))
+        XCTAssertTrue("HÉLLoWorlD  Apple".contains(predicate))
+        XCTAssertFalse("ApplEGoodbyeWorld".contains(predicate))
+    }
    
-   func testAndPredicates() {
+    func testAndPredicates() {
        let predicate = "H" && ("e" || "i") && "llo"
        XCTAssertTrue("Hello".contains(predicate))
        XCTAssertTrue("Hillo".contains(predicate))
        XCTAssertFalse("Hallo".contains(predicate))
        XCTAssertFalse("Hiyo".contains(predicate))
-   }
-   
-   func testIndirectStringPredicate() {
+    }
+
+    func testIndirectStringPredicate() {
        let predicate = ("Hello" || "World") && "!"
        XCTAssertTrue("Hello!".contains(predicate))
        XCTAssertTrue("World!".contains(predicate))
        XCTAssertFalse("Hello".contains(predicate))
-   }
-   
-   func testNestedStringPredicate() {
+    }
+
+    func testNestedStringPredicate() {
        let predicate = "Hello" || ("W" && ("o" || "i") && "r" && "l" && "d")
        XCTAssertTrue("Hello".contains(predicate))
        XCTAssertTrue("World".contains(predicate))
        XCTAssertTrue("Wirld".contains(predicate))
        XCTAssertFalse("Goodbye".contains(predicate))
-   }
+    }
 
-   func testDiacriticInsensitiveLowercase() {
-        let predicate = "héllo" || "wórld"
-        XCTAssertTrue("hello".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertTrue("world".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertFalse("goodbye".contains(predicate, diacriticAndCaseInsensitive: true))
+    func testDiacriticInsensitiveLowercase() {
+        let predicate = ~"héllo" || ~"wórld"
+        XCTAssertTrue("hello".contains(predicate))
+        XCTAssertTrue("world".contains(predicate))
+        XCTAssertFalse("goodbye".contains(predicate))
     }
 
     func testDiacriticInsensitiveUppercase() {
-        let predicate = "héllo" || "wórld"
-        XCTAssertTrue("HELLO".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertTrue("WORLD".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertFalse("GOODBYE".contains(predicate, diacriticAndCaseInsensitive: true))
+        let predicate = ~"héllo" || ~"wórld"
+        XCTAssertTrue("HELLO".contains(predicate))
+        XCTAssertTrue("WORLD".contains(predicate))
+        XCTAssertFalse("GOODBYE".contains(predicate))
     }
 
     func testDiacriticInsensitiveMixedcase() {
-        let predicate = "héllo" || "wórld"
-        XCTAssertTrue("Hello".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertTrue("World".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertTrue("HeLLo".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertTrue("wORLD".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertFalse("Goodbye".contains(predicate, diacriticAndCaseInsensitive: true))
+        let predicate = ~"héllo" || ~"wórld"
+        XCTAssertTrue("Hello".contains(predicate))
+        XCTAssertTrue("World".contains(predicate))
+        XCTAssertTrue("HeLLo".contains(predicate))
+        XCTAssertTrue("wORLD".contains(predicate))
+        XCTAssertFalse("Goodbye".contains(predicate))
     }
 
     func testDiacriticInsensitiveMixedcaseWithOtherChars() {
-        let predicate = "héllo" || "wórld"
-        XCTAssertTrue("Hello!".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertTrue("World?".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertTrue("HeLLo.".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertTrue("wORLD-".contains(predicate, diacriticAndCaseInsensitive: true))
-        XCTAssertFalse("Goodbye".contains(predicate, diacriticAndCaseInsensitive: true))
+        let predicate = ~"héllo" || ~"wórld"
+        XCTAssertTrue("Hello!".contains(predicate))
+        XCTAssertTrue("World?".contains(predicate))
+        XCTAssertTrue("HeLLo.".contains(predicate))
+        XCTAssertTrue("wORLD-".contains(predicate))
+        XCTAssertFalse("Goodbye".contains(predicate))
     }
 }

--- a/Tests/StringContainsOperatorsTests/StringContainsOperatorsTests.swift
+++ b/Tests/StringContainsOperatorsTests/StringContainsOperatorsTests.swift
@@ -56,4 +56,36 @@ final class StringContainsOperatorsTests: XCTestCase {
        XCTAssertTrue("Wirld".contains(predicate))
        XCTAssertFalse("Goodbye".contains(predicate))
    }
+
+   func testDiacriticInsensitiveLowercase() {
+        let predicate = "héllo" || "wórld"
+        XCTAssertTrue("hello".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertTrue("world".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertFalse("goodbye".contains(predicate, diacriticAndCaseInsensitive: true))
+    }
+
+    func testDiacriticInsensitiveUppercase() {
+        let predicate = "héllo" || "wórld"
+        XCTAssertTrue("HELLO".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertTrue("WORLD".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertFalse("GOODBYE".contains(predicate, diacriticAndCaseInsensitive: true))
+    }
+
+    func testDiacriticInsensitiveMixedcase() {
+        let predicate = "héllo" || "wórld"
+        XCTAssertTrue("Hello".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertTrue("World".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertTrue("HeLLo".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertTrue("wORLD".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertFalse("Goodbye".contains(predicate, diacriticAndCaseInsensitive: true))
+    }
+
+    func testDiacriticInsensitiveMixedcaseWithOtherChars() {
+        let predicate = "héllo" || "wórld"
+        XCTAssertTrue("Hello!".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertTrue("World?".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertTrue("HeLLo.".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertTrue("wORLD-".contains(predicate, diacriticAndCaseInsensitive: true))
+        XCTAssertFalse("Goodbye".contains(predicate, diacriticAndCaseInsensitive: true))
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds an optional parameter to the `contains` method of the `String` class to allow case and diacritic insensitive search. https://github.com/Tavernari/StringContainsOperators/issues/2

## Changes Made

- Added an optional parameter `diacriticAndCaseInsensitive` to the `contains` method of the `String` class.
- When `diacriticAndCaseInsensitive` is set to `true`, the method ignores case and diacritics when searching for a substring.
- Also added a new `containsIgnoringDiacriticsAndCase` method to the `StringProtocol` protocol to facilitate case and diacritic insensitive search.
- Modified the existing `contains` method to use the new parameter and method when appropriate.
- Added unit tests to ensure the new functionality works as expected.

## Examples

The following examples demonstrate how the new functionality can be used:

```swift
// Case and diacritic sensitive search
let predicate1 = "António" || "Costa"
"Antonio".contains(predicate1) // false

// Case and diacritic insensitive search
let predicate = "Antônio" || "António"
"Antonio".contains(predicate2, diacriticAndCaseInsensitive: true) // true
```

## Why

This change allows for more flexible searching of substrings within a string, making it easier to find relevant results without worrying about case or diacritics. This can be particularly useful in situations where user input is involved, as it allows for more forgiving search results.
