### PR TITLE
Introducing negatable operator ! for StringContainsOperators

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ print(result4) // true
 // Check if text contains "fox" AND ("Jumps" OR "swift") case insensitively and without diacritics
 let result5 = text.contains(~"fox" && (~"Jumps" || ~"swift"))
 print(result5) // true
+
+// Check if text does NOT contain "cat" AND "bird"
+let result6 = text.contains(!"cat" && !"bird")
+print(result6) // true
+
+// Check if text does NOT contain "brown"
+let result7 = text.contains(!"brown")
+print(result7) // false
+
+// Check if text does NOT contain "cat" case insensitively and without diacritics
+let result8 = text.contains(!~"cat")
+print(result8) // true
 ```
 
 ## How to Install

--- a/Sources/StringContainsOperators/SearchStrategies/NegatablePredicateSearchStrategy.swift
+++ b/Sources/StringContainsOperators/SearchStrategies/NegatablePredicateSearchStrategy.swift
@@ -1,0 +1,29 @@
+//
+//  NegatablePredicateSearchStrategy.swift
+//  
+//
+//  Created by Victor C Tavernari on 24/03/2023.
+//
+
+import Foundation
+
+/// A search strategy that negates the result of another search strategy.
+final class NegatablePredicateSearchStrategy: SearchStrategy {
+
+    let searchStrategy: SearchStrategy
+
+    init(searchStrategy: SearchStrategy) {
+
+        self.searchStrategy = searchStrategy
+    }
+
+    /// Evaluates the given string with the negated search strategy.
+    ///
+    /// - Parameter string: The string to be evaluated.
+    /// - Returns: `true` if the given string does not match the original search strategy, `false` otherwise.
+    func evaluate(string: String) -> Bool {
+
+        return !self.searchStrategy.evaluate(string: string)
+    }
+}
+

--- a/Sources/StringContainsOperators/SearchStrategies/NegatableValueSearchStrategy.swift
+++ b/Sources/StringContainsOperators/SearchStrategies/NegatableValueSearchStrategy.swift
@@ -1,0 +1,29 @@
+//
+//  NegatableValueSearchStrategy.swift
+//  
+//
+//  Created by Victor C Tavernari on 24/03/2023.
+//
+
+import Foundation
+
+/// A search strategy that negates the presence of a given value in a string.
+final class NegatableValueSearchStrategy: SearchStrategy {
+
+    let value: String
+
+    init(value: String) {
+
+        self.value = value
+    }
+
+    /// Evaluates the given string with the negated value search strategy.
+    ///
+    /// - Parameter string: The string to be evaluated.
+    /// - Returns: `true` if the given string does not contain the value, `false` otherwise.
+    func evaluate(string: String) -> Bool {
+
+        return !string.contains(self.value)
+    }
+}
+

--- a/Sources/StringContainsOperators/SearchStrategyMaker.swift
+++ b/Sources/StringContainsOperators/SearchStrategyMaker.swift
@@ -38,6 +38,12 @@ enum SearchStrategyMaker {
 
         case let .diacriticAndCaseInsensitive(value):
             return DiacriticAndCaseInsensitiveSearchStrategy(value: value)
+
+        case let .negatable(value):
+            return NegatableValueSearchStrategy(value: value)
+
+        case let .negatablePredicate(predicate):
+            return NegatablePredicateSearchStrategy(searchStrategy: self.make(predicate: predicate))
         }
     }
 }

--- a/Sources/StringContainsOperators/StringContainsOperators.swift
+++ b/Sources/StringContainsOperators/StringContainsOperators.swift
@@ -9,6 +9,7 @@ import Foundation
 infix operator || : LogicalDisjunctionPrecedence
 infix operator && : LogicalConjunctionPrecedence
 prefix operator ~
+prefix operator !
 
 /// An enum representing a string search predicate.
 public indirect enum StringPredicate {
@@ -33,62 +34,118 @@ public indirect enum StringPredicate {
 
     /// Represents a case-insensitive and diacritic-insensitive search for a given string.
     case diacriticAndCaseInsensitive(String)
+
+    case negatable(String)
+
+    case negatablePredicate(StringPredicate)
 }
 
 /// Returns a `StringPredicate` that performs a logical OR operation between two strings.
+/// - Parameters:
+///   - lhs: The first string to be evaluated.
+///   - rhs: The second string to be evaluated.
+/// - Returns: A `StringPredicate` that performs a logical OR operation between two strings.
 public func || (lhs: String, rhs: String) -> StringPredicate {
 
     return .or([lhs, rhs])
 }
 
 /// Returns a `StringPredicate` that performs a logical OR operation between a string and a `StringPredicate`.
+/// - Parameters:
+///   - lhs: The string to be evaluated.
+///   - rhs: The `StringPredicate` to be evaluated.
+/// - Returns: A `StringPredicate` that performs a logical OR operation between a string and a `StringPredicate`.
 public func || (lhs: String, rhs: StringPredicate) -> StringPredicate {
 
     return .orPredicates(lhs, rhs)
 }
 
 /// Returns a `StringPredicate` that performs a logical OR operation between a `StringPredicate` and a string.
+/// - Parameters:
+///   - lhs: The `StringPredicate` to be evaluated.
+///   - rhs: The string to be evaluated.
+/// - Returns: A `StringPredicate` that performs a logical OR operation between a `StringPredicate` and a string.
 public func || (lhs: StringPredicate, rhs: String) -> StringPredicate {
 
     return .orPredicates(rhs, lhs)
 }
 
 /// Returns a `StringPredicate` that performs a logical OR operation between two `StringPredicate`s.
+/// - Parameters:
+///   - lhs: The first `StringPredicate` to be evaluated.
+///   - rhs: The second `StringPredicate` to be evaluated.
+/// - Returns: A `StringPredicate` that performs a logical OR operation between two `StringPredicate`s.
 public func || (lhs: StringPredicate, rhs: StringPredicate) -> StringPredicate {
 
     return .orOnlyPredicates([rhs, lhs])
 }
 
 /// Returns a `StringPredicate` that performs a logical AND operation between two strings.
+/// - Parameters:
+///   - lhs: The first string to be evaluated.
+///   - rhs: The second string to be evaluated.
+/// - Returns: A `StringPredicate` that performs a logical AND operation between two strings.
 public func && (lhs: String, rhs: String) -> StringPredicate {
 
     return .and([lhs, rhs])
 }
 
 /// Returns a `StringPredicate` that performs a logical AND operation between a string and a `StringPredicate`.
+/// - Parameters:
+///   - lhs: The string to be evaluated.
+///   - rhs: The `StringPredicate` to be evaluated.
+/// - Returns: A `StringPredicate` that performs a logical AND operation between a string and a `StringPredicate`.
 public func && (lhs: String, rhs: StringPredicate) -> StringPredicate {
 
     return .andPredicates(lhs, rhs)
 }
 
 /// Returns a `StringPredicate` that performs a logical AND operation between a `StringPredicate` and a string.
+/// - Parameters:
+///   - lhs: The `StringPredicate` to be evaluated.
+///   - rhs: The string to be evaluated.
+/// - Returns: A `StringPredicate` that performs a logical AND operation between a `StringPredicate` and a string.
 public func && (lhs: StringPredicate, rhs: String) -> StringPredicate {
 
     return .andPredicates(rhs, lhs)
 }
 
 /// Returns a `StringPredicate` that performs a logical AND operation between two `StringPredicate`s.
+/// - Parameters:
+///   - lhs: The first `StringPredicate` to be evaluated.
+///   - rhs: The second `StringPredicate` to be evaluated.
+/// - Returns: A `StringPredicate
 public func && (lhs: StringPredicate, rhs: StringPredicate) -> StringPredicate {
 
     return .andOnlyPredicates([rhs, lhs])
 }
 
 /// Returns a `StringPredicate` that performs a case-insensitive and diacritic-insensitive search for a given string.
+///
+/// - Parameter value: The value to be evaluated.
+/// - Returns: A `StringPredicate` that performs a case-insensitive and diacritic-insensitive search for a given string.
 public prefix func ~ (value: String) -> StringPredicate {
 
     return .diacriticAndCaseInsensitive(value)
 }
 
+/// Returns a `StringPredicate` that negates another `StringPredicate`.
+///
+/// - Parameter predicate: The predicate to be negated.
+/// - Returns: A `StringPredicate` that represents the negation of the given predicate.
+public prefix func ! (predicate: StringPredicate) -> StringPredicate {
+
+    return .negatablePredicate(predicate)
+}
+
+/// Returns a `StringPredicate` that negates a given value.
+///
+/// - Parameter value: The value to be negated.
+/// - Returns: A `StringPredicate` that represents the negation of the given value.
+public prefix func ! (value: String) -> StringPredicate {
+
+    return .negatable(value)
+}
 
 public extension String {
 

--- a/Tests/StringContainsOperatorsTests/StringContainsOperatorsTests.swift
+++ b/Tests/StringContainsOperatorsTests/StringContainsOperatorsTests.swift
@@ -102,4 +102,15 @@ final class StringContainsOperatorsTests: XCTestCase {
         XCTAssertTrue("wORLD-".contains(predicate))
         XCTAssertFalse("Goodbye".contains(predicate))
     }
+
+    func testNegatablePredicate() {
+        let text = "Hello my little friend"
+
+        XCTAssertTrue(text.contains(!"fiance"))
+        XCTAssertFalse(text.contains(!"my"))
+        XCTAssertTrue(text.contains(!("enemy" && "little")))
+        XCTAssertFalse(text.contains(!("friend" && "little")))
+        XCTAssertTrue(text.contains(!("enemy" || "big")))
+        XCTAssertFalse(text.contains(!("friend" || "big")))
+    }
 }


### PR DESCRIPTION
This PullRequest adds a new negatable operator ! for StringContainsOperators that can be used to negate a StringPredicate or a simple string. This new feature provides an intuitive way to express the logical NOT operation in string search predicates.

Usage Examples:

```swift
import StringContainsOperators

let text = "The quick brown fox jumps over the lazy dog."

// Check if text does NOT contain "cat" AND "bird"
let result1 = text.contains(!"cat" && !"bird")
print(result1) // true

// Check if text does NOT contain "fox" OR "bird"
let result2 = text.contains(!("fox" || "bird"))
print(result2) // false

// Check if text does NOT contain "brown" case insensitively and without diacritics
let result3 = text.contains(!(~"brown"))
print(result3) // false

// Check if text does NOT contain "jumps" AND ("cat" OR "dog")
let result4 = text.contains(!("jumps" && ("cat" || "dog")))
print(result4) // true

// Check if text does NOT contain "lazy" case insensitively and without diacritics AND ("jumps" OR "swift")
let result5 = text.contains(!(~"lazy" && ("jumps" || "swift")))
print(result5) // false
```

With this new operator, the code becomes more readable and the logic of the search predicates is easier to follow.

I hope you find this feature useful and thank you in advance for your feedback.